### PR TITLE
CI: run in Node 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
         - Node.js 19.x
         - Node.js 20.x
         - Node.js 21.x
+        - Node.js 22.x
 
         include:
         - name: Node.js 0.10
@@ -134,6 +135,9 @@ jobs:
 
         - name: Node.js 21.x
           node-version: "21.6"
+
+        - name: Node.js 22.x
+          node-version: "22.0"
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Node 22 just became the "current" Node.js release and will be the next LTS version. Add it to version matrix in CI.